### PR TITLE
Redesign repo list as card grid with richer GitHub metadata

### DIFF
--- a/src/components/Portfolio/index.css
+++ b/src/components/Portfolio/index.css
@@ -1,0 +1,153 @@
+.repo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+@media (max-width: 600px) {
+  .repo-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.repo-card {
+  background-color: #161b22;
+  border: 1px solid rgba(88, 166, 255, 0.15);
+  border-radius: 8px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.repo-card:hover {
+  border-color: rgba(88, 166, 255, 0.45);
+  box-shadow: 0 0 0 1px rgba(88, 166, 255, 0.1);
+}
+
+.repo-card--archived {
+  opacity: 0.6;
+}
+
+.repo-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.repo-card__name {
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #58a6ff;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.repo-card__name:hover {
+  text-decoration: underline;
+  color: #58a6ff;
+}
+
+.repo-card__icon {
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.repo-card__homepage {
+  color: #8b949e;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+  transition: color 0.2s ease;
+}
+
+.repo-card__homepage:hover {
+  color: #cdd9e5;
+}
+
+.repo-card__description {
+  font-size: 0.82rem;
+  color: #8b949e;
+  line-height: 1.5;
+  margin: 0;
+  flex-grow: 1;
+  max-width: none;
+}
+
+.repo-card__no-desc {
+  font-style: italic;
+  opacity: 0.5;
+}
+
+.repo-card__topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.repo-card__topic {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background-color: rgba(88, 166, 255, 0.1);
+  color: #58a6ff;
+  border: 1px solid rgba(88, 166, 255, 0.2);
+}
+
+.repo-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 0.4rem;
+  border-top: 1px solid rgba(88, 166, 255, 0.08);
+}
+
+.repo-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.repo-card__language {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: #adbac7;
+}
+
+.repo-card__language-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.repo-card__stat {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: #8b949e;
+}
+
+.repo-card__stat i {
+  font-size: 0.7rem;
+}
+
+.repo-card__updated {
+  font-size: 0.75rem;
+  color: #8b949e;
+}

--- a/src/components/Portfolio/index.tsx
+++ b/src/components/Portfolio/index.tsx
@@ -1,11 +1,46 @@
 import React, { useState, useEffect } from 'react'
+import './index.css'
+
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: '#3178c6',
+  JavaScript: '#f1e05a',
+  Python: '#3572A5',
+  HTML: '#e34c26',
+  CSS: '#563d7c',
+  SCSS: '#c6538c',
+  Shell: '#89e051',
+  Go: '#00ADD8',
+  Rust: '#dea584',
+  Java: '#b07219',
+  'C++': '#f34b7d',
+  C: '#555555',
+  Ruby: '#701516',
+  Swift: '#f05138',
+  Kotlin: '#A97BFF',
+  Dart: '#00B4AB',
+  Vue: '#41b883',
+  PHP: '#4F5D95',
+}
 
 interface Repository {
   name: string
   pushed_at: string
   html_url: string
   description: string
+  language: string | null
+  stargazers_count: number
+  forks_count: number
+  topics: string[]
+  homepage: string | null
+  archived: boolean
   daysSinceLastChange?: number
+}
+
+function formatTimeAgo(days: number): string {
+  if (days <= 1) return 'yesterday'
+  if (days < 30) return `${days}d ago`
+  if (days < 365) return `${Math.round(days / 30)}mo ago`
+  return `${Math.round(days / 365)}y ago`
 }
 
 const Portfolio: React.FC = () => {
@@ -13,19 +48,20 @@ const Portfolio: React.FC = () => {
 
   useEffect(() => {
     const getRepos = async () => {
-      const response = await fetch('https://api.github.com/users/maxkrieg/repos')
+      const response = await fetch('https://api.github.com/users/maxkrieg/repos?per_page=100', {
+        headers: { Accept: 'application/vnd.github+json' },
+      })
       const data: Repository[] = await response.json()
       data.sort((repoA: any, repoB: any) => {
         const aDate = new Date(repoA.pushed_at)
         const bDate = new Date(repoB.pushed_at)
         return bDate.getTime() - aDate.getTime()
       })
-      const reposToDisplay = data.slice(0, 5)
+      const reposToDisplay = data.slice(0, 8)
       const today = new Date()
       reposToDisplay.forEach((repo) => {
         const diffTime = Math.abs(today.getTime() - new Date(repo.pushed_at).getTime())
-        const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
-        repo.daysSinceLastChange = diffDays
+        repo.daysSinceLastChange = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
       })
       setRepos(reposToDisplay)
     }
@@ -34,7 +70,7 @@ const Portfolio: React.FC = () => {
 
   return (
     <div>
-      <p style={{ marginBottom: '16px' }}>
+      <p style={{ marginBottom: '2rem' }}>
         While most of my code is written for work, below is a list of some recent (or potentially
         not recent) contributions on personal projects. Head over to my{' '}
         <a href="https://github.com/maxkrieg" target="_blank" rel="noopener noreferrer">
@@ -42,17 +78,60 @@ const Portfolio: React.FC = () => {
         </a>{' '}
         for all of my code.
       </p>
-      <ul>
-        {repos.map((repo: Repository, i: number) => (
-          <li key={i} style={{ listStyle: 'none', fontSize: '14px' }}>
-            <a href={repo.html_url} target="_blank" rel="noopener noreferrer">
-              {repo.name}
-            </a>{' '}
-            // {repo.description} //{' '}
-            {repo.daysSinceLastChange! > 1 ? `${repo.daysSinceLastChange} days ago` : 'yesterday'}
-          </li>
+      <div className="repo-grid">
+        {repos.map((repo: Repository) => (
+          <div key={repo.name} className={`repo-card${repo.archived ? ' repo-card--archived' : ''}`}>
+            <div className="repo-card__header">
+              <a href={repo.html_url} target="_blank" rel="noopener noreferrer" className="repo-card__name">
+                <i className="fas fa-book repo-card__icon"></i>
+                {repo.name}
+              </a>
+              {repo.homepage && (
+                <a href={repo.homepage} target="_blank" rel="noopener noreferrer" className="repo-card__homepage" title="Live site">
+                  <i className="fas fa-external-link-alt"></i>
+                </a>
+              )}
+            </div>
+
+            <p className="repo-card__description">
+              {repo.description || <span className="repo-card__no-desc">No description</span>}
+            </p>
+
+            {repo.topics && repo.topics.length > 0 && (
+              <div className="repo-card__topics">
+                {repo.topics.slice(0, 4).map((topic) => (
+                  <span key={topic} className="repo-card__topic">{topic}</span>
+                ))}
+              </div>
+            )}
+
+            <div className="repo-card__footer">
+              <div className="repo-card__meta">
+                {repo.language && (
+                  <span className="repo-card__language">
+                    <span
+                      className="repo-card__language-dot"
+                      style={{ backgroundColor: LANGUAGE_COLORS[repo.language] || '#8b949e' }}
+                    />
+                    {repo.language}
+                  </span>
+                )}
+                {repo.stargazers_count > 0 && (
+                  <span className="repo-card__stat">
+                    <i className="fas fa-star"></i> {repo.stargazers_count}
+                  </span>
+                )}
+                {repo.forks_count > 0 && (
+                  <span className="repo-card__stat">
+                    <i className="fas fa-code-branch"></i> {repo.forks_count}
+                  </span>
+                )}
+              </div>
+              <span className="repo-card__updated">{formatTimeAgo(repo.daysSinceLastChange!)}</span>
+            </div>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Replaces the plain unordered list with a responsive 2-column card grid.
Each card shows: repo name (linked), description, topic chips, primary
language with color dot, star/fork counts, and time since last push.
Bumps displayed repo count from 5 to 8.

https://claude.ai/code/session_01ERpv4xQhWZNqqZTHrkLLcZ