### PR TITLE
Add Google Analytics 4 tracking for page views and link clicks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,16 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Max Krieg</title>
+
+    <!-- Google Analytics (GA4) -->
+    <!-- Replace G-XXXXXXXXXX with your Measurement ID from Google Analytics > Admin > Data Streams -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXXXXX');
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import { Container, Row, Col } from 'react-bootstrap'
 
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void
+  }
+}
+
 import sections from './content/sections'
 import Navbar from './components/Navbar'
 import ParticleHero from './components/ParticleHero'
@@ -12,6 +18,20 @@ function App() {
 
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 })
   const [spotlightActive, setSpotlightActive] = useState(false)
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      const anchor = (e.target as HTMLElement).closest('a')
+      if (!anchor || !window.gtag) return
+      window.gtag('event', 'link_click', {
+        link_url: anchor.href,
+        link_text: anchor.textContent?.trim() || anchor.getAttribute('aria-label') || '',
+        outbound: anchor.hostname !== window.location.hostname,
+      })
+    }
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [])
 
   useEffect(() => {
     const onMove = (e: MouseEvent) => {


### PR DESCRIPTION
- Adds GA4 gtag.js script to public/index.html (placeholder ID G-XXXXXXXXXX)
- Adds global click handler in App.tsx that fires a 'link_click' GA4 event
  with link_url, link_text, and outbound flag for every anchor click

Replace G-XXXXXXXXXX in public/index.html with the real Measurement ID
from Google Analytics > Admin > Data Streams once the GA4 property is created.

https://claude.ai/code/session_01LjjbCAHKJ2nsXeA2KbK9ea